### PR TITLE
Revert "Bump linked_list_allocator from 0.9.1 to 0.10.2 in the cargo group"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "lazy_static",
- "linked_list_allocator",
+    "linked_list_allocator",
  "pc-keyboard",
  "pic8259",
  "spin",
@@ -58,11 +58,11 @@ dependencies = [
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98908d64cd118e4a3fb26803bd2aef3e7796f1d494517c89b8fea19b92b8c12"
+checksum = "549ce1740e46b291953c4340adcd74c59bcf4308f4cac050fd33ba91b7168f4a"
 dependencies = [
- "spinning_top",
+    "spinning_top",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
- "lock_api",
+    "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ uart_16550 = "0.3.2"
 x86_64 = "0.14.2"
 pic8259 = "0.10.1"
 pc-keyboard = "0.8.0"
-linked_list_allocator = "0.10.2"
+linked_list_allocator = "0.9.0"
 
 [dependencies.lazy_static]
 version = "1.0"


### PR DESCRIPTION
Reverts BindraAgamjot256/PortfoliOS#7